### PR TITLE
Update base to recommended

### DIFF
--- a/default.json
+++ b/default.json
@@ -2,7 +2,7 @@
     "$schema": "https://docs.renovatebot.com/renovate-schema.json",
     "description": "Default Renovate configuration for all repositories in this organization",
     "extends": [
-      "config:base",
+      "config:recommended",
       "helpers:pinGitHubActionDigests",
       ":semanticCommitsDisabled"
     ],


### PR DESCRIPTION
In renovate v36 they changed the option "base" to "recommended"